### PR TITLE
lag.zig: use simd + mixin methods

### DIFF
--- a/src/lag.zig
+++ b/src/lag.zig
@@ -1,114 +1,90 @@
-pub fn Vec2(comptime T: type) type {
+const std = @import("std");
+
+pub fn VecMethods(comptime T: type, comptime fields_len: u8, comptime Self: type) type {
     return struct {
+        const A = [fields_len]T;
+        pub inline fn asArray(self: Self) A {
+            return @bitCast(A, self);
+        }
+        pub inline fn fromArray(a: A) Self {
+            return @bitCast(Self, a);
+        }
+
+        const Simd = std.meta.Vector(fields_len, T);
+        pub inline fn asSimd(self: Self) Simd {
+            return @bitCast(Simd, self);
+        }
+        pub inline fn fromSimd(v: Simd) Self {
+            return @bitCast(Self, v);
+        }
+
+        pub fn add(self: Self, other: Self) Self {
+            return fromSimd(self.asSimd() + other.asSimd());
+        }
+
+        pub fn sub(self: Self, other: Self) Self {
+            return fromSimd(self.asSimd() - other.asSimd());
+        }
+
+        pub fn scale(self: Self, scalar: T) Self {
+            return fromSimd(self.asSimd() * @splat(fields_len, scalar));
+        }
+
+        pub fn mag(self: Self) T {
+            return @sqrt(@reduce(.Add, self.asSimd() * self.asSimd()));
+        }
+
+        pub fn unit(self: Self) Self {
+            return self.scale(1 / self.mag());
+        }
+
+        pub fn eq(self: Self, other: Self) bool {
+            return @reduce(.And, self.asSimd() == other.asSimd());
+        }
+
+        pub fn zero() Self {
+            return fromArray([1]T{0} ** fields_len);
+        }
+    };
+}
+
+pub fn Vec2(comptime T: type) type {
+    return struct { // in case of problems, maybe try changing this to 'extern struct'
         x: T,
         y: T,
 
-        pub fn init(x: T, y: T) Vec2(T) {
-            return Vec2(T){
+        const Self = @This();
+        pub fn init(x: T, y: T) Self {
+            return .{
                 .x = x,
                 .y = y,
             };
         }
 
-        pub fn zero() Vec2(T) {
-            return Vec2(T){
-                .x = 0,
-                .y = 0,
-            };
-        }
-
-        pub fn add(self: Vec2(T), other: Vec2(T)) Vec2(T) {
-            return Vec2(T){
-                .x = self.x + other.x,
-                .y = self.y + other.y,
-            };
-        }
-
-        pub fn sub(self: Vec2(T), other: Vec2(T)) Vec2(T) {
-            return Vec2(T){
-                .x = self.x - other.x,
-                .y = self.y - other.y,
-            };
-        }
-
-        pub fn scale(self: Vec2(T), scalar: f32) Vec2(T) {
-            return Vec2(T){
-                .x = self.x * scalar,
-                .y = self.y * scalar,
-            };
-        }
-
-        pub fn mag(self: Vec2(T)) f32 {
-            return @sqrt(self.x * self.x + self.y * self.y + self.z * self.z);
-        }
-
-        pub fn unit(self: Vec2(T)) Vec2(T) {
-            return self.scale(1 / self.mag());
-        }
-
-        pub fn eq(self: Vec2(T), other: Vec2(T)) bool {
-            return self.x == other.x and self.y == other.y;
-        }
+        pub usingnamespace VecMethods(T, 2, Self);
     };
 }
 
+// this implementation has an extra padding field to support simd conversions via @bitCast
 pub fn Vec3(comptime T: type) type {
     return struct {
-        x: T,
+        x: T, // x: T align(16), <-- compiles but results in runtime alignment error
         y: T,
         z: T,
+        // padding is required to allow bitcasting. without this compiler error: non power of 2 alignment
+        _padding: T = 1,
 
-        pub fn init(x: T, y: T, z: T) Vec3(T) {
-            return Vec3(T){
+        const Self = @This();
+        pub fn init(x: T, y: T, z: T) Self {
+            return .{
                 .x = x,
                 .y = y,
                 .z = z,
             };
         }
 
-        pub fn zero() Vec3(T) {
-            return Vec3(T){
-                .x = 0,
-                .y = 0,
-                .z = 0,
-            };
-        }
-
-        pub fn add(self: Vec3(T), other: Vec3(T)) Vec3(T) {
-            return Vec3(T){
-                .x = self.x + other.x,
-                .y = self.y + other.y,
-                .z = self.z + other.z,
-            };
-        }
-
-        pub fn sub(self: Vec3(T), other: Vec3(T)) Vec3(T) {
-            return Vec3(T){
-                .x = self.x - other.x,
-                .y = self.y - other.y,
-                .z = self.z - other.z,
-            };
-        }
-
-        pub fn scale(self: Vec3(T), scalar: f32) Vec3(T) {
-            return Vec3(T){
-                .x = self.x * scalar,
-                .y = self.y * scalar,
-                .z = self.z * scalar,
-            };
-        }
-
-        pub fn mag(self: Vec3(T)) f32 {
-            return @sqrt(self.x * self.x + self.y * self.y + self.z * self.z);
-        }
-
-        pub fn unit(self: Vec3(T)) Vec3(T) {
-            return self.scale(1 / self.mag());
-        }
-
-        pub fn eq(self: Vec3(T), other: Vec3(T)) bool {
-            return self.x == other.x and self.y == other.y and self.z == other.z;
-        }
+        // fields_len = 4 rather than 3 is required to allow bitcasting with same size
+        pub usingnamespace VecMethods(T, 4, Self);
     };
 }
 


### PR DESCRIPTION
As you can likely guess, i'm tw0st3p on twitch.  This is just a fun
patch to see if i could make lag work with simd and also use a mixin
struct to get rid of some repitition.  I think its pretty neat.  But
ofcourse, take it or leave it.

Not sure but I imagine it would be more performant even with the extra
padding field in Vec3 due to using simd instructions.

Note that i initially implemented using `extern struct` within Vec2 and Vec3 but changed to a regular `struct` to see if the compiler would complain.  It seems to work fine, even with `zig build run -Drelease-fast`. 